### PR TITLE
MorpherState.transfer() is platform only but can transfer for every addr

### DIFF
--- a/contracts/MorpherState.sol
+++ b/contracts/MorpherState.sol
@@ -186,8 +186,8 @@ contract MorpherState is Ownable {
         _;
     }
 
-    modifier canTransfer(address sender) {
-        require(getCanTransfer(sender), "MorpherState: Caller may not transfer token. Aborting.");
+    modifier canTransfer {
+        require(getCanTransfer(msg.sender), "MorpherState: Caller may not transfer token. Aborting.");
         _;
     }
 
@@ -430,7 +430,7 @@ contract MorpherState is Ownable {
     // Minting/burning/transfer of token
     // ----------------------------------------------------------------------------
 
-    function transfer(address _from, address _to, uint256 _token) public onlyPlatform notPaused canTransfer(_from) {
+    function transfer(address _from, address _to, uint256 _token) public onlyPlatform notPaused {
         require(balances[_from] >= _token, "MorpherState: Not enough token.");
         balances[_from] = balances[_from].sub(_token);
         balances[_to] = balances[_to].add(_token);


### PR DESCRIPTION
Had to reverse the change for canTransfer in State, because it will ultimately block all staking efforts for all users, since staking calls .transfer in the name of the user. And users would have to be enabled for transfer in state. 

Anyways, State.transfer is onlyPlatform.